### PR TITLE
feat(admin): adding dynamic order count summaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,19 @@
-# VITE_API_ADDRESS="http://games.westlan.local:5001/api/"
+# production
+# VITE_ATTENDEE_COUNT=62
+# VITE_API_ADDRESS="[actual url]"
+# VITE_REDIRECT_ADDRESS="[actual url]"
+# VITE_CLIENT_ID="[actual id]"
+# VITE_STAFF_1_ID="[actual id]"
+# VITE_STAFF_2_ID="[actual id]"
+# VITE_STAFF_3_ID="[actual id]"
+# VITE_STAFF_4_ID="[actual id]"
+
+# development
+VITE_ATTENDEE_COUNT=62
+VITE_API_ADDRESS="[actual url]"
+VITE_REDIRECT_ADDRESS="[actual url]"
+VITE_CLIENT_ID="[actual id]"
+VITE_STAFF_1_ID="[actual id]"
+VITE_STAFF_2_ID="[actual id]"
+VITE_STAFF_3_ID="[actual id]"
+VITE_STAFF_4_ID="[actual id]"

--- a/src/Components/AdminPanel/AdminPanelContent.tsx
+++ b/src/Components/AdminPanel/AdminPanelContent.tsx
@@ -26,6 +26,9 @@ import { basicOrderType, PanelContentProps } from '../../Context/Types';
 import TableContent from './TableContent';
 import LockButtonContent from './LockButtonContent';
 import COLOURS from '../../Theme/Colours';
+import AttendeeSummaryTableHeader from './AttendeeSummaryTableHeader';
+import OrderSummaryTableHeader from './OrderSummaryTableHeader';
+import BREAKFAST_OPTIONS from '../BreakfastOptions';
 
 export const StyledTableCell1 = styled(TableCell)(() => ({
   // table head styling
@@ -54,6 +57,7 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
   const navigate = useNavigate();
   const {
     allOrdersData: allOrders,
+    allOrdersLength,
     isLoadingAllOrders,
     updateOrder,
     forceInvalidate: forceInvalidateOrders,
@@ -70,12 +74,54 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
   const [loadingSpinner, setLoadingSpinner] = useState<boolean>(false);
   const [stateTableData, setStateTableData] = useState<basicOrderType[]>([]);
   const lockedStatus = lockedStatusData[0].value;
+  // TODO: this needs to be updated somehow better than manually defined in .env
+  const attendeeTotal: number = import.meta.env.VITE_ATTENDEE_COUNT;
+  const ordersMissing: number = attendeeTotal - allOrdersLength;
+  let fatBastardCount: number = 0;
+  let sausageBaconCount: number = 0;
+  let sausageEggCount: number = 0;
+  let eggBaconCount: number = 0;
+  let onlyBaconCount: number = 0;
+  let onlySausageCount: number = 0;
+  let onlyEggCount: number = 0;
+
+  const orderTypeCountSwitch = (type: string) => {
+    switch (type) {
+      case BREAKFAST_OPTIONS.FAT_BASTARD:
+        fatBastardCount += 1;
+        break;
+      case BREAKFAST_OPTIONS.SAUSAGE_AND_BACON:
+        sausageBaconCount++;
+        break;
+      case BREAKFAST_OPTIONS.SAUSAGE_AND_EGG:
+        sausageEggCount++;
+        break;
+      case BREAKFAST_OPTIONS.EGG_AND_BACON:
+        eggBaconCount++;
+        break;
+      case BREAKFAST_OPTIONS.ONLY_BACON:
+        onlyBaconCount++;
+        break;
+      case BREAKFAST_OPTIONS.ONLY_SAUSAGE:
+        onlySausageCount++;
+        break;
+      case BREAKFAST_OPTIONS.ONLY_EGG:
+        onlyEggCount++;
+        break;
+    }
+  };
+
+  if (allOrdersLength > 0) {
+    stateTableData.forEach((order: unknown) => {
+      orderTypeCountSwitch((order as basicOrderType).orderType);
+    });
+  }
 
   useEffect(() => {
-    if (allOrders) {
+    if (allOrders !== undefined) {
       setStateTableData(allOrders);
     }
-  }, [allOrders]);
+  }, [allOrders, stateTableData]);
 
   const colourModeChangeHandler = () => {
     if (useColourMode === false) {
@@ -97,6 +143,7 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
         paddingBottom: '3rem',
       }}
     >
+      {/* left column of the page */}
       <Grid
         item
         xs={2}
@@ -112,12 +159,15 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
         </Button>
       </Grid>
 
+      {/* centre column of the page */}
       <Grid item xs={8} sx={{ marginTop: '2rem' }}>
+        {/* 1st table - attendee summary */}
         <TableContainer
           sx={{
             padding: '2rem',
             backgroundColor: COLOURS.DARK_BUTTON_HOVER_BACKGROUND,
             borderRadius: '1rem',
+            marginBottom: '2rem',
           }}
         >
           <Stack alignItems="flex-start">
@@ -132,11 +182,89 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
                 textSizeAdjust: '100%',
               }}
             >
+              Attendee Summary
+            </Typography>
+            <Table>
+              <AttendeeSummaryTableHeader />
+              <TableBody
+                sx={{
+                  backgroundColor: COLOURS.DARK_TABLE_CELL_BACKGROUND,
+                }}
+              >
+                <StyledTableRow>
+                  <StyledTableCell1 align="center">{attendeeTotal}</StyledTableCell1>
+                  <StyledTableCell1 align="center">{allOrdersLength}</StyledTableCell1>
+                  <StyledTableCell1 align="center">{ordersMissing.toString()}</StyledTableCell1>
+                </StyledTableRow>
+              </TableBody>
+            </Table>
+          </Stack>
+
+          {/* 2nd table - Order summary */}
+          <Stack alignItems="flex-start">
+            <Typography
+              sx={{
+                display: 'flex',
+                color: COLOURS.DARK_FONT_PRIMARY,
+                fontSize: '1.25rem',
+                lineHeight: '1.75rem',
+                fontWeight: '700',
+                paddingY: '0.5rem',
+                textSizeAdjust: '100%',
+              }}
+            >
+              Order Summary
+            </Typography>
+            <Table>
+              <OrderSummaryTableHeader />
+              <TableBody
+                sx={{
+                  backgroundColor: COLOURS.DARK_TABLE_CELL_BACKGROUND,
+                }}
+              >
+                <StyledTableRow>
+                  <StyledTableCell1 align="center">{fatBastardCount}</StyledTableCell1>
+                  <StyledTableCell1 align="center">{sausageBaconCount}</StyledTableCell1>
+                  <StyledTableCell1 align="center">{sausageEggCount}</StyledTableCell1>
+                  <StyledTableCell1 align="center">{eggBaconCount}</StyledTableCell1>
+                  <StyledTableCell1 align="center">{onlyBaconCount}</StyledTableCell1>
+                  <StyledTableCell1 align="center">{onlySausageCount}</StyledTableCell1>
+                  <StyledTableCell1 align="center">{onlyEggCount}</StyledTableCell1>
+                </StyledTableRow>
+              </TableBody>
+            </Table>
+          </Stack>
+        </TableContainer>
+
+        {/* 3rd table - order list */}
+        <TableContainer
+          sx={{
+            padding: '2rem',
+            backgroundColor: COLOURS.DARK_BUTTON_HOVER_BACKGROUND,
+            borderRadius: '1rem',
+          }}
+        >
+          {/* Table title */}
+          <Stack alignItems="flex-start">
+            <Typography
+              sx={{
+                display: 'flex',
+                color: COLOURS.DARK_FONT_PRIMARY,
+                fontSize: '1.25rem',
+                lineHeight: '1.75rem',
+                fontWeight: '700',
+                paddingY: '0.5rem',
+                textSizeAdjust: '100%',
+              }}
+            >
               Order List
             </Typography>
+
+            {/*  table colour controls */}
             <Grid container alignItems="center" justifyContent="space-between">
               <Grid item>
                 <Stack direction="row">
+                  {/* checkbox 1 */}
                   <FormControlLabel
                     sx={{ color: COLOURS.DARK_TABLE_FONT, marginLeft: '0rem' }}
                     control={
@@ -155,6 +283,7 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
                     }
                     label="Strikethrough on complete"
                   />
+                  {/* checkbox 2 */}
                   <FormControlLabel
                     sx={{ color: COLOURS.DARK_TABLE_FONT, marginLeft: '0rem' }}
                     control={
@@ -173,6 +302,7 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
                     }
                     label="Order Type Colours"
                   />
+                  {/* checkbox 3 */}
                   {useColourMode && (
                     <FormControlLabel
                       sx={{ color: COLOURS.DARK_TABLE_FONT, marginLeft: '0rem' }}
@@ -195,6 +325,8 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
                   )}
                 </Stack>
               </Grid>
+
+              {/* order status | right hand side */}
               <Grid item>
                 <Typography>Order status: {lockedStatus ? 'locked' : 'unlocked'}</Typography>
                 <Button
@@ -222,6 +354,7 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
           </Stack>
 
           {!isLoadingAllOrders && allOrders && allOrders.length > 0 ? (
+            // Dynamic table with orders
             <TableContent
               orderList={stateTableData}
               setStateTableData={setStateTableData}
@@ -232,6 +365,7 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
               strikethrough={strikethrough}
             />
           ) : (
+            // Empty display when no orders
             <Table>
               <TableBody
                 sx={{
@@ -251,6 +385,8 @@ const AdminPanelContent: FC<PanelContentProps> = ({ userName }) => {
           )}
         </TableContainer>
       </Grid>
+
+      {/* right column of the page */}
       <Grid item xs={2} />
     </Grid>
   );

--- a/src/Components/AdminPanel/AttendeeSummaryTableHeader.tsx
+++ b/src/Components/AdminPanel/AttendeeSummaryTableHeader.tsx
@@ -1,0 +1,49 @@
+// libraries
+import { FC } from 'react';
+import { TableCell, TableHead, TableRow } from '@mui/material';
+import GroupsIcon from '@mui/icons-material/Groups';
+import LunchDiningIcon from '@mui/icons-material/LunchDining';
+import WarningIcon from '@mui/icons-material/Warning';
+// files
+import COLOURS from '../../Theme/Colours';
+
+interface HeadCell {
+  id: string;
+  label: string;
+  icon: JSX.Element;
+}
+
+const headCells: readonly HeadCell[] = [
+  {
+    id: 'attendeeTotal',
+    label: 'Attendee Total',
+    icon: <GroupsIcon />,
+  },
+  {
+    id: 'orderTotal',
+    label: 'Orders Logged',
+    icon: <LunchDiningIcon />,
+  },
+  {
+    id: 'missingTotal',
+    label: 'Orders Missing',
+    icon: <WarningIcon />,
+  },
+];
+
+const AttendeeSummaryTableHeader: FC = () => {
+  return (
+    <TableHead sx={{ backgroundColor: COLOURS.DARK_MODE_BUTTON_LIGHT }}>
+      <TableRow>
+        {headCells.map((headCell) => (
+          <TableCell key={headCell.id} align="center" sx={{ color: COLOURS.DARK_FONT_PRIMARY }}>
+            {headCell.label}
+            <span style={{ verticalAlign: 'middle', marginLeft: '0.5rem' }}>{headCell.icon}</span>
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+};
+
+export default AttendeeSummaryTableHeader;

--- a/src/Components/AdminPanel/OrderSummaryTableHeader.tsx
+++ b/src/Components/AdminPanel/OrderSummaryTableHeader.tsx
@@ -1,0 +1,50 @@
+// libraries
+import { FC } from 'react';
+import { TableCell, TableHead, TableRow } from '@mui/material';
+// files
+import COLOURS from '../../Theme/Colours';
+import BREAKFAST_OPTIONS from '../BreakfastOptions';
+
+interface HeadCell {
+  label: string;
+}
+
+const headCells: readonly HeadCell[] = [
+  {
+    label: BREAKFAST_OPTIONS.FAT_BASTARD,
+  },
+  {
+    label: BREAKFAST_OPTIONS.SAUSAGE_AND_BACON,
+  },
+  {
+    label: BREAKFAST_OPTIONS.SAUSAGE_AND_EGG,
+  },
+  {
+    label: BREAKFAST_OPTIONS.EGG_AND_BACON,
+  },
+  {
+    label: BREAKFAST_OPTIONS.ONLY_BACON,
+  },
+  {
+    label: BREAKFAST_OPTIONS.ONLY_SAUSAGE,
+  },
+  {
+    label: BREAKFAST_OPTIONS.ONLY_EGG,
+  },
+];
+
+const OrderSummaryTableHeader: FC = () => {
+  return (
+    <TableHead sx={{ backgroundColor: COLOURS.DARK_MODE_BUTTON_LIGHT }}>
+      <TableRow>
+        {headCells.map((headCell, iterator) => (
+          <TableCell key={iterator} align="center" sx={{ color: COLOURS.DARK_FONT_PRIMARY }}>
+            {headCell.label}
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+};
+
+export default OrderSummaryTableHeader;

--- a/src/Components/AdminPanel/TableContent.tsx
+++ b/src/Components/AdminPanel/TableContent.tsx
@@ -97,6 +97,7 @@ const TableContent: FC<TableContentProps> = ({
     [forceInvalidate, setStateTableData, updateOrder],
   );
 
+  // TODO: this is the issue with the checkboxes, this doesn't update the state order
   const visibleRows = useMemo(
     () => stableSort(orderList, getComparator(orderDirection, valueToOrderBy)),
     [getComparator, orderDirection, orderList, valueToOrderBy],

--- a/src/Components/AdminPanel/TableHeader.tsx
+++ b/src/Components/AdminPanel/TableHeader.tsx
@@ -2,11 +2,9 @@
 import { FC, MouseEvent } from 'react';
 import { Box, TableBody, TableCell, TableRow, TableSortLabel } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
-// providers
 // files
 import ascDescEnum from './ascDescEnum';
 import { basicOrderType } from '../../Context/Types';
-// import { Order } from './TableContent';
 import COLOURS from '../../Theme/Colours';
 
 interface HeadCell {

--- a/src/Queries/useOrder.ts
+++ b/src/Queries/useOrder.ts
@@ -116,6 +116,7 @@ const useOrder = (userName: string) => {
     userOrderError,
     isLoadingUserOrder,
     allOrdersData,
+    allOrdersLength: allOrdersData?.length,
     allOrdersError,
     isLoadingAllOrders,
     createOrder: createMutation.mutate,

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -24,7 +24,7 @@ const Admin: FC = () => {
       sx={{
         width: '100vw',
         maxWidth: '100vw',
-        height: '100vh',
+        height: '100%',
         backgroundColor: darkMode ? COLOURS.DARK_MODE_BUTTON_LIGHT : COLOURS.LIGHT_SECONDARY,
       }}
     >


### PR DESCRIPTION
- added a count for attendees
- added a count for orders logged
- added a count for orders missing
- added dynamic counts for the various orders sorted by type
- added a return from useOrders hook for the length of the orderList being fetched
- created 2 additional tables with their own header components
- fixed the issue with the background colour being dark grey when list of tables was long
- cleaned up the env example file